### PR TITLE
fix: x버튼 클릭할 경우 인풋창 비활성화를 활성화로 변경 #1

### DIFF
--- a/src/components/SearchInput/Input.tsx
+++ b/src/components/SearchInput/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import LabelForInput from '@components/common/LabelForInput';
 import SearchIcon from '@components/common/SearchIcon';
 import { SearchInputInputProps } from '@type/props';
@@ -24,6 +24,8 @@ function Input({
   setSelectedIndex,
   maxIndex,
 }: SearchInputInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const getUpIndex = (prevIndex: number) => {
     if (prevIndex <= 0) return maxIndex;
     return prevIndex - 1;
@@ -60,7 +62,9 @@ function Input({
     setIsInputTextFocus(true);
   };
 
-  const onClickCancel = () => {
+  const onClickCancel = (e: React.MouseEvent<HTMLSpanElement>) => {
+    e.preventDefault();
+    inputRef.current?.focus();
     setInputText('');
   };
 
@@ -79,6 +83,7 @@ function Input({
           )}
           <SearchInput
             id={INPUT_ID}
+            ref={inputRef}
             type="search"
             spellCheck="false"
             value={inputText}


### PR DESCRIPTION
## 추가한 기능 설명
x버튼 클릭할 경우 인풋창 비활성화 되는 경우를 활성화되도록 변경함
<br>

## check list

- [0 ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
